### PR TITLE
Fix argument list too long error in CI builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -61,6 +61,7 @@ else:
     disable_module("smooth", cannot_compile)
 
     disable_module("goost", "Temporarily disabled")
+    disable_module("gif", "Temporarily disabled")
 
 # Append the default `extra_suffix` to distinguish between other builds.
 args.append("extra_suffix=community")

--- a/SConstruct
+++ b/SConstruct
@@ -60,6 +60,8 @@ else:
     disable_module("lua", cannot_compile)
     disable_module("smooth", cannot_compile)
 
+    disable_module("git", "Temporarily disabled")
+
 # Append the default `extra_suffix` to distinguish between other builds.
 args.append("extra_suffix=community")
 os.environ["BUILD_NAME"] = "community"

--- a/SConstruct
+++ b/SConstruct
@@ -61,7 +61,6 @@ else:
     disable_module("smooth", cannot_compile)
 
     disable_module("goost", "Temporarily disabled")
-    disable_module("gif", "Temporarily disabled")
 
 # Append the default `extra_suffix` to distinguish between other builds.
 args.append("extra_suffix=community")

--- a/SConstruct
+++ b/SConstruct
@@ -60,6 +60,8 @@ else:
     disable_module("lua", cannot_compile)
     disable_module("smooth", cannot_compile)
 
+    disable_module("goost", "Temporarily disabled")
+
 # Append the default `extra_suffix` to distinguish between other builds.
 args.append("extra_suffix=community")
 os.environ["BUILD_NAME"] = "community"

--- a/SConstruct
+++ b/SConstruct
@@ -60,8 +60,6 @@ else:
     disable_module("lua", cannot_compile)
     disable_module("smooth", cannot_compile)
 
-    disable_module("goost", "Temporarily disabled")
-
 # Append the default `extra_suffix` to distinguish between other builds.
 args.append("extra_suffix=community")
 os.environ["BUILD_NAME"] = "community"


### PR DESCRIPTION
Trying to fix:
```
scons: *** [modules/libmodules.x11.opt.tools.64.community.a] sh: Argument list too long
```
Not sure the cause at the moment, will try to narrow down with this PR...